### PR TITLE
Add new air flow data point DPT 9.009

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -33,7 +33,7 @@ var connection = new knx.Connection( {
       // you also WRITE to an explicit datapoint type, eg. DPT9.001 is temperature Celcius
       connection.write("2/1/0", 22.5, "DPT9.001");
       // you can also issue a READ request and pass a callback to capture the response
-      connection.read("1/0/1", (src, responsevalue) => { ... });
+      connection.read("1/0/1", (err, src, responsevalue) => { ... });
     },
     // get notified for all KNX events:
     event: function(evt, src, dest, value) { console.log(

--- a/README-events.md
+++ b/README-events.md
@@ -16,9 +16,9 @@ connection.on('GroupValue_Response', function (src, dest, value) { ... });
 
 // Specific group address event: device with 'src' physical address
 // .. wrote to group address
-connection.on('GroupValue_Write_1/2/3', function (src, value) { ... });
+connection.on('GroupValue_Write_1/2/3', function (err, src, value) { ... });
 // .. or responded about current value
-connection.on('GroupValue_Response_1/2/3', function (src, value) { ... });
+connection.on('GroupValue_Response_1/2/3', function (err, src, value) { ... });
 
 // there's also the generic catch-all event which passes the event type
 // as its 1st argument, along with all the other info

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,7 @@ type DatapointOptions = {
   ga: KnxGroupAddress;
   dpt?: DPT;
   autoread?: boolean;
+  readReqTimeout?: number;
 };
 
 interface DatapointEvent {

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ declare module "knx" {
     debug: boolean;
     Connect(): void;
     Disconnect(cb?: () => void): void;
-    read(ga: KnxGroupAddress, cb?: (src: KnxDeviceAddress, value: Buffer) => void): void;
+    read(ga: KnxGroupAddress, cb?: (err: Error, src: KnxDeviceAddress, value: Buffer) => void): void;
     write(ga: KnxGroupAddress, value: Buffer, dpt: DPT, cb?: () => void): void;
   }
 
@@ -97,7 +97,7 @@ declare module "knx" {
     constructor(conf: ConnectionSpec);
     Connect(): void;
     Disconnect(cb?: () => void): void;
-    read(ga: KnxGroupAddress, cb?: (src: KnxDeviceAddress, value: Buffer) => void): void;
+    read(ga: KnxGroupAddress, cb?: (err: Error, src: KnxDeviceAddress, value: Buffer) => void): void;
     write(ga: KnxGroupAddress, value: Buffer, dpt: DPT, cb?: () => void): void;
     writeRaw(
       ga: KnxGroupAddress,
@@ -114,6 +114,6 @@ declare module "knx" {
     constructor(options: DatapointOptions, conn?: IConnection);
     bind(conn: Connection): void;
     write(value: KnxValue): void;
-    read(callback?: (src: KnxDeviceAddress, value: KnxValue) => void): void;
+    read(callback?: (err: Error, src: KnxDeviceAddress, value: KnxValue) => void): void;
   }
 }

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -271,7 +271,7 @@ FSM.prototype.read = function (options, callback) {
       const err = new Error(msg);
       KnxLog.get().warn(msg);
       binding(err, null, null);
-    }, readReqTimeout | 3000);
+    }, readReqTimeout || 3000);
   }
   const serviceType = this.useTunneling ?
     KnxConstants.SERVICE_TYPE.TUNNELING_REQUEST :

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -1,7 +1,7 @@
 /**
-* knx.js - a KNX protocol stack in pure Javascript
-* (C) 2016-2018 Elias Karakoulakis
-*/
+ * knx.js - a KNX protocol stack in pure Javascript
+ * (C) 2016-2018 Elias Karakoulakis
+ */
 
 const util = require('util');
 
@@ -12,7 +12,7 @@ const KnxConstants = require('./KnxConstants');
 const KnxNetProtocol = require('./KnxProtocol');
 
 // bind incoming UDP packet handler
-FSM.prototype.onUdpSocketMessage = function(msg, rinfo, callback) {
+FSM.prototype.onUdpSocketMessage = function (msg, rinfo, callback) {
   // get the incoming packet's service type ...
   try {
     const reader = KnxNetProtocol.createReader(msg);
@@ -36,21 +36,21 @@ FSM.prototype.onUdpSocketMessage = function(msg, rinfo, callback) {
       }
       this.handle(signal, dg);
     }
-  } catch(err) {
+  } catch (err) {
     KnxLog.get().debug('(%s): Incomplete/unparseable UDP packet: %s: %s',
-      this.compositeState(),err, msg.toString('hex')
+      this.compositeState(), err, msg.toString('hex')
     );
   }
 };
 
-FSM.prototype.AddConnState = function(datagram) {
+FSM.prototype.AddConnState = function (datagram) {
   datagram.connstate = {
     channel_id: this.channel_id,
     state: 0
   }
 }
 
-FSM.prototype.AddTunnState = function(datagram) {
+FSM.prototype.AddTunnState = function (datagram) {
   // add the remote IP router's endpoint
   datagram.tunnstate = {
     channel_id: this.channel_id,
@@ -67,7 +67,7 @@ const AddCRI = (datagram) => {
   }
 }
 
-FSM.prototype.AddCEMI = function(datagram, msgcode) {
+FSM.prototype.AddCEMI = function (datagram, msgcode) {
   const sendAck = ((msgcode || 0x11) == 0x11) && !this.options.suppress_ack_ldatareq; // only for L_Data.req
   datagram.cemi = {
     msgcode: msgcode || 0x11, // default: L_Data.req for tunneling
@@ -104,7 +104,7 @@ FSM.prototype.AddCEMI = function(datagram, msgcode) {
  *    if a function is passed, use this to DECORATE
  *    if NULL, then just make a new empty datagram. Look at AddXXX methods
  */
-FSM.prototype.Request = function(type, datagram_template, callback) {
+FSM.prototype.Request = function (type, datagram_template, callback) {
   // populate skeleton datagram
   const datagram = this.prepareDatagram(type);
   // decorate the datagram, if a function is passed
@@ -120,14 +120,14 @@ FSM.prototype.Request = function(type, datagram_template, callback) {
 }
 
 // prepare a datagram for the given service type
-FSM.prototype.prepareDatagram = function(svcType) {
+FSM.prototype.prepareDatagram = function (svcType) {
   const datagram = {
-      "header_length": 6,
-      "protocol_version": 16, // 0x10 == version 1.0
-      "service_type": svcType,
-      "total_length": null, // filled in automatically
-    }
-    //
+    "header_length": 6,
+    "protocol_version": 16, // 0x10 == version 1.0
+    "service_type": svcType,
+    "total_length": null, // filled in automatically
+  }
+  //
   AddHPAI(datagram);
   //
   switch (svcType) {
@@ -158,7 +158,7 @@ FSM.prototype.prepareDatagram = function(svcType) {
 /*
 send the datagram over the wire
 */
-FSM.prototype.send = function(datagram, callback) {
+FSM.prototype.send = function (datagram, callback) {
   var cemitype; // TODO: set, but unused
   try {
     this.writer = KnxNetProtocol.createWriter();
@@ -190,7 +190,7 @@ FSM.prototype.send = function(datagram, callback) {
   }
 }
 
-FSM.prototype.write = function(grpaddr, value, dptid, callback) {
+FSM.prototype.write = function (grpaddr, value, dptid, callback) {
   if (grpaddr == null || value == null) {
     KnxLog.get().warn('You must supply both grpaddr and value!');
     return;
@@ -200,7 +200,7 @@ FSM.prototype.write = function(grpaddr, value, dptid, callback) {
     const serviceType = this.useTunneling ?
       KnxConstants.SERVICE_TYPE.TUNNELING_REQUEST :
       KnxConstants.SERVICE_TYPE.ROUTING_INDICATION;
-    this.Request(serviceType, function(datagram) {
+    this.Request(serviceType, function (datagram) {
       DPTLib.populateAPDU(value, datagram.cemi.apdu, dptid);
       datagram.cemi.dest_addr = grpaddr;
     }, callback);
@@ -209,7 +209,7 @@ FSM.prototype.write = function(grpaddr, value, dptid, callback) {
   }
 }
 
-FSM.prototype.respond = function(grpaddr, value, dptid) {
+FSM.prototype.respond = function (grpaddr, value, dptid) {
   if (grpaddr == null || value == null) {
     KnxLog.get().warn('You must supply both grpaddr and value!');
     return;
@@ -217,7 +217,7 @@ FSM.prototype.respond = function(grpaddr, value, dptid) {
   const serviceType = this.useTunneling ?
     KnxConstants.SERVICE_TYPE.TUNNELING_REQUEST :
     KnxConstants.SERVICE_TYPE.ROUTING_INDICATION;
-  this.Request(serviceType, function(datagram) {
+  this.Request(serviceType, function (datagram) {
     DPTLib.populateAPDU(value, datagram.cemi.apdu, dptid);
     // this is a READ request
     datagram.cemi.apdu.apci = "GroupValue_Response";
@@ -226,7 +226,7 @@ FSM.prototype.respond = function(grpaddr, value, dptid) {
   });
 }
 
-FSM.prototype.writeRaw = function(grpaddr, value, bitlength, callback) {
+FSM.prototype.writeRaw = function (grpaddr, value, bitlength, callback) {
   if (grpaddr == null || value == null) {
     KnxLog.get().warn('You must supply both grpaddr and value!');
     return;
@@ -239,7 +239,7 @@ FSM.prototype.writeRaw = function(grpaddr, value, bitlength, callback) {
   const serviceType = this.useTunneling ?
     KnxConstants.SERVICE_TYPE.TUNNELING_REQUEST :
     KnxConstants.SERVICE_TYPE.ROUTING_INDICATION;
-  this.Request(serviceType, function(datagram) {
+  this.Request(serviceType, function (datagram) {
     datagram.cemi.apdu.data = value;
     datagram.cemi.apdu.bitlength = bitlength ? bitlength : (value.byteLength * 8);
     datagram.cemi.dest_addr = grpaddr;
@@ -248,23 +248,25 @@ FSM.prototype.writeRaw = function(grpaddr, value, bitlength, callback) {
 
 // send a READ request to the bus
 // you can pass a callback function which gets bound to the RESPONSE datagram event
-FSM.prototype.read = function(options, callback) {
+FSM.prototype.read = function (options, callback) {
   const { ga: grpaddr, readReqTimeout } = options;
   if (typeof callback == 'function') {
     // when the response arrives:
     const responseEvent = 'GroupValue_Response_' + grpaddr;
     KnxLog.get().trace('Binding connection to ' + responseEvent);
     const binding = (err, src, data) => {
-        // unbind the event handler
-        this.off(responseEvent, binding);
-        // fire the callback
-        callback(err, src, data);
-      }
-      // prepare for the response
+      // unbind the event handler
+      this.off(responseEvent, binding);
+      // unbind the timeout handler
+      clearTimeout(timeout);
+      // fire the callback
+      callback(err, src, data);
+    }
+    // prepare for the response
     this.on(responseEvent, binding);
     // per default clean up after 3 seconds just in case no one answers the read request
     // you can customize this by passing a readReqTimeout in the options object
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       const msg = 'Read request timed out';
       const err = new Error(msg);
       KnxLog.get().warn(msg);
@@ -274,7 +276,7 @@ FSM.prototype.read = function(options, callback) {
   const serviceType = this.useTunneling ?
     KnxConstants.SERVICE_TYPE.TUNNELING_REQUEST :
     KnxConstants.SERVICE_TYPE.ROUTING_INDICATION;
-  this.Request(serviceType, function(datagram) {
+  this.Request(serviceType, function (datagram) {
     // this is a READ request
     datagram.cemi.apdu.apci = "GroupValue_Read";
     datagram.cemi.dest_addr = grpaddr;
@@ -282,25 +284,25 @@ FSM.prototype.read = function(options, callback) {
   });
 }
 
-FSM.prototype.Disconnect = function(cb) {
+FSM.prototype.Disconnect = function (cb) {
   var that = this;
 
-  if(this.state === 'connecting') {
-      KnxLog.get().debug('Disconnecting directly');
-      that.transition("uninitialized");
-      if(cb) {
-        cb()
-      }
-      return
+  if (this.state === 'connecting') {
+    KnxLog.get().debug('Disconnecting directly');
+    that.transition("uninitialized");
+    if (cb) {
+      cb()
+    }
+    return
   }
 
   KnxLog.get().debug('waiting for Idle-State');
-  this.onIdle(function() {
+  this.onIdle(function () {
     KnxLog.get().trace('In Idle-State');
 
     that.on('disconnected', () => {
       KnxLog.get().debug('Disconnected from KNX');
-      if(cb) {
+      if (cb) {
         cb()
       }
     });
@@ -313,14 +315,13 @@ FSM.prototype.Disconnect = function(cb) {
   // this.off();
 }
 
-FSM.prototype.onIdle = function(cb) {
-  if(this.state === 'idle') {
+FSM.prototype.onIdle = function (cb) {
+  if (this.state === 'idle') {
     KnxLog.get().trace('Connection is already Idle');
     cb();
-  }
-  else {
-    this.on("transition", function(data) {
-      if(data.toState === 'idle') {
+  } else {
+    this.on("transition", function (data) {
+      if (data.toState === 'idle') {
         KnxLog.get().trace('Connection just transitioned to Idle');
         cb();
       }
@@ -332,7 +333,7 @@ FSM.prototype.onIdle = function(cb) {
 const datagramDesc = (dg) => {
   let blurb = KnxConstants.keyText('SERVICE_TYPE', dg.service_type);
   if (dg.service_type == KnxConstants.SERVICE_TYPE.TUNNELING_REQUEST ||
-      dg.service_type == KnxConstants.SERVICE_TYPE.ROUTING_INDICATION) {
+    dg.service_type == KnxConstants.SERVICE_TYPE.ROUTING_INDICATION) {
     blurb += '_' + KnxConstants.keyText('MESSAGECODES', dg.cemi.msgcode);
   }
   return blurb;
@@ -352,7 +353,7 @@ const AddTunn = (datagram) => {
   datagram.tunn = {
     protocol_type: 1, // UDP
     tunnel_endpoint: '0.0.0.0:0'
-      //tunnel_endpoint: this.localAddress + ":" + this.tunnel.address().port
+    //tunnel_endpoint: this.localAddress + ":" + this.tunnel.address().port
   };
 }
 

--- a/src/Datapoint.js
+++ b/src/Datapoint.js
@@ -113,9 +113,9 @@ class Datapoint extends EventEmitter {
    */
   read(callback) {
     if (!this.conn) throw 'must supply a valid KNX connection to bind to';
-    this.conn.read(this.options.ga, (src, buf) => {
-      const jsvalue = DPTLib.fromBuffer(buf, this.dpt);
-      if (typeof callback == 'function') callback(src, jsvalue);
+    this.conn.read(this.options, (err, src, buf) => {
+      const jsvalue = err ? null : DPTLib.fromBuffer(buf, this.dpt);
+      if (typeof callback == 'function') callback(err, src, jsvalue);
     });
   }
 

--- a/src/FSM.js
+++ b/src/FSM.js
@@ -586,6 +586,7 @@ module.exports = machina.Fsm.extend({
     // 'GroupValue_Write_1/2/3', src, data
     this.emit(
       util.format('%s_%s', evtName, datagram.cemi.dest_addr),
+      null,
       datagram.cemi.src_addr,
       datagram.cemi.apdu.data
     );

--- a/src/dptlib/dpt9.js
+++ b/src/dptlib/dpt9.js
@@ -139,6 +139,14 @@ exports.subtypes = {
     range: [0, 670760],
   },
 
+  // 9.009 cubic meter/hour (m³/h)
+  '009': {
+    name: 'DPT_Value_AirFlow',
+    desc: 'air flow',
+    unit: 'm³/h',
+    range: [-670760, 670760],
+  },
+
   // 9.010 time (s)
   '010': {
     name: 'DPT_Value_Time1',

--- a/test/wiredtests/test-logotimer.js
+++ b/test/wiredtests/test-logotimer.js
@@ -26,7 +26,13 @@ if (process.env.hasOwnProperty('WIREDTEST')) {
           timer_control.on('change', function(oldvalue, newvalue) {
             t.pass(util.format("**** Timer control changed from: %j to: %j", oldvalue, newvalue));
           });
-          timer_status.read(function(src, response) {
+          timer_status.read(function(err, src, response) {
+            if(err) {
+              console.log("%s **** ERROR: %j",
+                new Date().toISOString().replace(/T/, ' ').replace(/Z$/, ''),
+                err);
+              process.exit(1);
+            }
             t.pass(util.format("**** Timer status response: %j", response));
             t.end();
             process.exit(0);

--- a/test/wiredtests/test-read.js
+++ b/test/wiredtests/test-read.js
@@ -27,7 +27,13 @@ if (process.env.hasOwnProperty('WIREDTEST')) {
             ga: options.dpt9_temperature_status_ga,
             dpt: 'DPT9.001'
           }, connection);
-          temperature_in.read(function(src, response) {
+          temperature_in.read(function(err, src, response) {
+            if(err) {
+              console.log("%s **** ERROR: %j",
+                new Date().toISOString().replace(/T/, ' ').replace(/Z$/, ''),
+                err);
+              process.exit(1);
+            }
             console.log("KNX response from %s: %j", src, response);
             t.pass(util.format('read temperature:  %s', response));
             t.end();


### PR DESCRIPTION
Introduces a new data point type, DPT 9.009, for measuring air flow in cubic meters per hour (m³/h). This update enhances the module's capability to handle a broader range of measurement units and improves its versatility in air flow management applications.